### PR TITLE
fix: automate build on publish and point main to dist

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
+src/
 test/
 jsonnet-example/
 foundation-sdk-example/

--- a/package.json
+++ b/package.json
@@ -1,15 +1,15 @@
 {
   "name": "@mikaello/grizzly-foundation-sdk-ts",
   "version": "1.2.2",
-  "main": "./dist/grizzly.js",
-  "types": "./dist/grizzly.d.ts",
+  "main": "./src/grizzly.ts",
   "type": "module",
   "description": "This library provides utilities for [Grizzly](https://github.com/grafana/grizzly), a utility for managing observability resources on Grafana and hosted Prometheus installations.",
   "repository": "github:mikaello/grizzly-foundation-sdk-ts",
   "scripts": {
     "verify-typescript": "tsc -p tsconfig.json --noEmit",
     "build": "tsc -p tsconfig.json",
-    "prepublishOnly": "npm run build",
+    "prepack": "npm run build && npm pkg set main='./dist/grizzly.js' types='./dist/grizzly.d.ts'",
+    "postpack": "npm pkg set main='./src/grizzly.ts' && npm pkg delete types",
     "test": "node --experimental-strip-types --test --test-reporter spec ./test/*.test.ts",
     "check-format": "prettier --check \"**/(*.ts?(x)|*.js?(x)|*.json|*.css|*.html|*.md?(x))\"",
     "format": "prettier --write \"**/(*.ts?(x)|*.js?(x)|*.json|*.css|*.html|*.md?(x))\""

--- a/package.json
+++ b/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@mikaello/grizzly-foundation-sdk-ts",
   "version": "1.2.2",
-  "main": "./src/grizzly.ts",
+  "main": "./dist/grizzly.js",
+  "types": "./dist/grizzly.d.ts",
   "type": "module",
   "description": "This library provides utilities for [Grizzly](https://github.com/grafana/grizzly), a utility for managing observability resources on Grafana and hosted Prometheus installations.",
   "repository": "github:mikaello/grizzly-foundation-sdk-ts",
   "scripts": {
     "verify-typescript": "tsc -p tsconfig.json --noEmit",
     "build": "tsc -p tsconfig.json",
+    "prepublishOnly": "npm run build",
     "test": "node --experimental-strip-types --test --test-reporter spec ./test/*.test.ts",
     "check-format": "prettier --check \"**/(*.ts?(x)|*.js?(x)|*.json|*.css|*.html|*.md?(x))\"",
     "format": "prettier --write \"**/(*.ts?(x)|*.js?(x)|*.json|*.css|*.html|*.md?(x))\""


### PR DESCRIPTION
- Add prepublishOnly script to run build before npm publish
- Update main field to point to compiled dist/grizzly.js
- Add types field pointing to dist/grizzly.d.ts
- Exclude src/ from published package since dist/ is the output

Closes #80